### PR TITLE
fix bug in write_results_to_excel for case of empty dataframes

### DIFF
--- a/pegasus/tools/diff_expr.py
+++ b/pegasus/tools/diff_expr.py
@@ -942,22 +942,22 @@ def write_results_to_excel(
         df.reset_index(inplace=True)
         worksheet = workbook.add_worksheet(name=sheet_name)
 
-        worksheet.add_table(
-            0,
-            0,
-            df.index.size,
-            df.columns.size - 1,
-            {
-                "data": df.to_numpy(),
-                "style": "Table Style Light 1",
-                "first_column": True,
-                "header_row": True,
-                "columns": [{"header": x} for x in df.columns.values],
-            },
-        )
-        # if df.shape[0] > 0:
-        # else:
-        #     worksheet.write_row(0, 0, df.columns.values)
+        if df.shape[0] > 0:
+            worksheet.add_table(
+                0,
+                0,
+                df.index.size,
+                df.columns.size - 1,
+                {
+                    "data": df.to_numpy(),
+                    "style": "Table Style Light 1",
+                    "first_column": True,
+                    "header_row": True,
+                    "columns": [{"header": x} for x in df.columns.values],
+                },
+            )
+        else:
+            worksheet.write_row(0, 0, df.columns.values)
 
     workbook = xlsxwriter.Workbook(output_file, {"nan_inf_to_errors": True})
     workbook.formats[0].set_font_size(9)


### PR DESCRIPTION
### Issue

When adding empty pandas DataFrame to a worksheet, the resulting excel file contains two unexpected features which generate warnings when opening:

* Autofilter: This can be resolved by setting ``autofilter`` option in ``worksheet.add_table`` to be ``False``.

* Table: I couldn't find a way to easily resolve it.

### Solution

My fix is case analysis:

1. When the data frame is not empty (``df.shape[0] > 0``), use the current ``add_table`` function.

2. When it's empty, only write one row of headers.