### PR TITLE
Replace fisher-modified by fisher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = [
     "anndata",
     "Cython",
     "docopt",
-    "fisher-modified",
+    "fisher>=0.1.9",
     "forceatlas2-python",
     "hnswlib",
     "joblib",


### PR DESCRIPTION
Python package "fisher" has merged Bo's modification since 0.1.9. So it can work with Python 3.7 now.

I've tested it with differential expression analysis on MantonBM_nonmix data with Louvain clusters on macOS. The two packages gave exactly the same result.