### PR TITLE
Fix bug in aggregate_matrix with sample sheet location to gs URL

### DIFF
--- a/pegasus/tools/data_aggregation.py
+++ b/pegasus/tools/data_aggregation.py
@@ -119,7 +119,7 @@ def aggregate_matrices(
             if not os.path.exists(dest_path):  # localize data
                 if copy_type == "directory":
                     check_call(["mkdir", "-p", dest_path])
-                    call_args = ["gsutil", "-m", "cp", "-r", copy_path, dest_path]
+                    call_args = ["gsutil", "-m", "rsync", "-r", copy_path, dest_path]
                 else:
                     call_args = ["gsutil", "-m", "cp", copy_path, dest_path]
                 check_call(call_args)


### PR DESCRIPTION
Use ``rsync`` instead of ``cp`` when copying a GS folder to local, since ``cp`` maintains the folder structure as a subdirectory of the target folder.

Otherwise, ``read_input`` will load a subdirectory, instead of the wanted ``mtx`` file.