### PR TITLE
Allow loading loom file using user-specified batch key and black list

### DIFF
--- a/pegasus/io/io.py
+++ b/pegasus/io/io.py
@@ -753,6 +753,11 @@ def read_input(
         data = load_loom_file(input_file, genome, ngene=ngene)
         if isinstance(data, anndata.AnnData):
             file_format = "h5ad"
+            if channel_attr is not None:
+                data.obs["Channel"] = data.obs[channel_attr]
+            for attr in black_list:
+                if attr in data.obs:
+                    data.obs.drop(columns = attr, inplace = True)
     else:
         assert file_format == "dge" or file_format == "csv" or file_format == "tsv"
         if genome is None:


### PR DESCRIPTION
## Issue to Fix
For the following code
```
adata = pg.read_input("source.loom", channel_attr = 'donor_organism.sex', black_list = ['attr1', 'attr2'])
```
neither the batch key is reset, nor attributes in the black list are filtered out.

Such functionality only works for loading ``h5ad`` file. But as SCP has asked for this feature, and we implemented it in the old scCloud version, we may still want it back.

## Functionality
When ``load_loom_file`` returns an ``AnnData`` object, apply ``channel_attr`` and ``black_list`` parameters.