### PR TITLE
set varm to empty when generating loom files

### DIFF
--- a/pegasus/pipeline/pipeline.py
+++ b/pegasus/pipeline/pipeline.py
@@ -385,6 +385,7 @@ def run_pipeline(input_file, output_name, **kwargs):
     io.write_output(adata, output_name + ".h5ad")
 
     if kwargs["output_loom"]:
+        adata.varm = {}
         io.write_output(adata, output_name + ".loom")
 
     print("Results are written.")


### PR DESCRIPTION
## Issue
When loading pegasus cluster loom output with ``--correct-batch-effect`` option, it fails. This is because batch correction step writes several multi-dimensional output to ``varm`` field, making the generated loom file not readable by ``anndata``.

## Solution
When generating clustering loom output, set ``varm`` to be an empty dictionary. This does not affect other output formats such as h5ad and seurat-compatible h5ad.