### PR TITLE
Fix bug on writing to mtx.gz

### DIFF
--- a/pegasus/io/io.py
+++ b/pegasus/io/io.py
@@ -882,7 +882,7 @@ def _write_mtx(data: "AnnData", output_file: str):
         features_df['gene_ids'] = data.var.index
         features_df['gene_names'] = data.var.index
     features_df['type'] = 'Gene Expression'
-    features_df.to_csv(os.path.join(output_dir, 'features.tsv.gz'), header=None, sep='\t')
+    features_df.to_csv(os.path.join(output_dir, 'features.tsv.gz'), header=None, sep='\t', index=False)
     data.obs.to_csv(os.path.join(output_dir, 'obs.csv.gz'), index_label='id')
     var_columns = list(data.var.columns)
     if 'gene_ids' in data.var:


### PR DESCRIPTION
This bug was brought in by Issue #42, and I was able to reproduce it.

The fix only affects ``features.tsv.gz`` when writing gene-count matrix in ``mtx`` format using:
```
pegasus.write_output(data, "result.mtx.gz")
```
by removing the redundant index column, which will cause reading the generated mtx files failed.