### PR TITLE
Bug Fix and API unification

### DIFF
--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -890,7 +890,7 @@ def dotplot(
     size_legend.grid(False)
 
     # Reset global settings.
-    sns.set(font_scale=1.0, style='whitegrid')
+    sns.set(font_scale=1.0, style='white')
 
     return fig if not show else None
 
@@ -982,6 +982,7 @@ def dendrogram(
         embed_df.set_index(data.obs[groupby], inplace=True)
 
     mean_df = embed_df.groupby(level=0).mean()
+    mean_df.index = mean_df.index.astype('category')
 
     from sklearn.cluster import AgglomerativeClustering
     from scipy.cluster.hierarchy import dendrogram
@@ -996,8 +997,6 @@ def dendrogram(
                     distance_threshold=distance_threshold
                 )
     clusterer.fit(corr_mat)
-
-    print(clusterer.distances_)
 
     counts = np.zeros(clusterer.children_.shape[0])
     n_samples = len(clusterer.labels_)
@@ -1014,7 +1013,7 @@ def dendrogram(
 
     fig, axis = plt.subplots(1, 1, figsize=figsize)
     dendrogram(linkage_matrix, labels=mean_df.index.categories, ax=axis, **kwargs)
-    plt.xticks(rotation=90, fontsize=8)
+    plt.xticks(rotation=90, fontsize=10)
     plt.tight_layout()
 
     return fig if not show else None

--- a/pegasus/tools/diff_expr.py
+++ b/pegasus/tools/diff_expr.py
@@ -863,7 +863,7 @@ def markers(
     results = defaultdict(dict)
     for clust_id, col_names in clust2cols.items():
         rec_names = [x + ":" + clust_id for x in col_names]
-        df = pd.DataFrame(data=rec_array[rec_names], index=data.var_names)
+        df = pd.DataFrame(data=rec_array[rec_names], index=data.var_names.copy())
         df.columns = col_names
         df.index.name = "feature"
 


### PR DESCRIPTION
* Fix bug in `pg.markers` which implicitly changes `data.var_names`. The consequence is that the saved file cannot be loaded by Pegasus.
* Fix bug in `pg.dendrogram` by enforcing the index of summary data frame to be categorical.
* Unify APIs of plotting functions:
    * Use `groupby` for cell attribute to group data;
    * Use `genes` for gene or gene list;
    * Use `attrs` for a possible combination of genes and cell attributes.