### PR TITLE
Cell type annotation function API

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -121,7 +121,7 @@ Annotate clusters:
 	:toctree: .
 
 	infer_cell_types
-	annotate
+	annotate_cluster
 
 Plotting
 --------

--- a/pegasus/__init__.py
+++ b/pegasus/__init__.py
@@ -62,7 +62,12 @@ from .tools import (
     infer_path,
     calc_signature_score,
 )
-from .annotate_cluster import infer_cell_types, annotate, infer_cluster_names
+from .annotate_cluster import (
+    infer_cell_types,
+    annotate,
+    infer_cluster_names,
+    annotate_cluster,
+)
 from .misc import search_genes, search_de_genes
 from .plotting import (
     scatter,

--- a/pegasus/annotate_cluster/__init__.py
+++ b/pegasus/annotate_cluster/__init__.py
@@ -4,4 +4,5 @@ from .annotate_cluster import (
     run_annotate_cluster,
     annotate_data_object,
     infer_cluster_names,
+    annotate_cluster,
 )


### PR DESCRIPTION
Add `pg.annotate_cluster` function:
* API: `pg.annotate_cluster(data, markers='human_immune', de_test='t', annotation_key='anno')`.
* Result: Update ``data.obs["anno"]`` with putative cell type annotations.