### PR TITLE
Add doublet detection using Scrublet

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -152,6 +152,16 @@ Demultiplexing
     demultiplex
     attach_demux_results
 
+Doublet Detection
+-------------------
+
+.. autosummary::
+    :toctree: .
+
+    run_scrublet
+    infer_doublets
+    mark_singlets
+
 Miscellaneous
 -------------
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -49,6 +49,18 @@ References
    "UMAP: Uniform Manifold Approximation and Projection for Dimension Reduction",
    Preprint at `arXiv <https://arxiv.org/abs/1802.03426>`_, 2018.
 
+.. [Pijuan-Sala19] B. Pijuan-Sala, et al.,
+   "A single-cell molecular map of mouse gastrulation and early organogenesis",
+   In `Nature <https://www.nature.com/articles/s41586-019-0933-9>`_, 2019.
+
+.. [Popescu19] D-M. Popescu, et al.,
+   "Decoding human fetal liver haematopoiesis",
+   In `Nature <https://www.nature.com/articles/s41586-019-1652-y>`_, 2019.
+
 .. [Traag19] V. A. Traag, L. Waltman, and N. J. van Eck,
    "From Louvain to Leiden: guaranteeing well-connected communities",
    In `Scientific Reports <https://www.nature.com/articles/s41598-019-41695-z>`_, 2019.
+
+.. [Wolock18] S.L. Wolock, R. Lopez, and A.M. Klein,
+   "Scrublet: computational identification of cell doublets in single-cell transcriptomic Data",
+   In `Cell Systems <https://www.sciencedirect.com/science/article/pii/S2405471218304745>`_, 2018.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,6 +7,7 @@ Version 1.0.0 `September 1, 2020`
         * Data are manipulated in Multi-modal structure in memory.
         * Support focus analysis on Unimodal data, and appending other Unimodal data to it. (``--focus`` and ``--append`` options in ``cluster`` command)
     * Calculate signature / gene module scores. (`calc_signature_score <api/pegasus.calc_signature_score.html>`_)
+    * `Doublet detection <api/index.html#doublet-detection>`_ based on `Scrublet <https://github.com/AllonKleinLab/scrublet>`_: ``run_scrublet``, ``infer_doublets``, and ``mark_singlets``.
     * Principal-Component-level regress out. (`pc_regress_out <api/pegasus.pc_regress_out.html>`_)
     * Batch correction using `Scanorama <https://github.com/brianhie/scanorama>`_. (`run_scanorama <api/pegasus.run_scanorama.html>`_)
     * Allow DE analysis with sample attribute as condition. (Set ``condition`` argument in `de_analysis <api/pegasus.de_analysis.html>`_)

--- a/pegasus/__init__.py
+++ b/pegasus/__init__.py
@@ -62,6 +62,7 @@ from .tools import (
     find_markers,
     infer_path,
     calc_signature_score,
+    run_scrublet,
     infer_doublets,
     mark_singlets,
 )

--- a/pegasus/tools/__init__.py
+++ b/pegasus/tools/__init__.py
@@ -40,4 +40,4 @@ from .diff_expr import de_analysis, markers, write_results_to_excel, run_de_anal
 from .gradient_boosting import find_markers, run_find_markers
 from .subcluster_utils import get_anndata_for_subclustering
 from .signature_score import calc_signature_score
-from .doublet_detection import infer_doublets, mark_singlets
+from .doublet_detection import run_scrublet, infer_doublets, mark_singlets

--- a/pegasus/tools/doublet_detection.py
+++ b/pegasus/tools/doublet_detection.py
@@ -106,6 +106,10 @@ def run_scrublet(
 ) -> None:
     """Calculate doublet scores using Scrublet.
 
+    This is a wrapper of `Scrublet <https://github.com/AllonKleinLab/scrublet>`_ package.
+
+    See [Wolock18]_ for details on this method.
+
     Parameters
     -----------
     data: ``MultimodalData`` object.
@@ -175,8 +179,9 @@ def infer_doublets(
     random_state: Optional[int] = 0,
     verbose: Optional[bool] = False,
 ) -> None:
-    """Infer doublets based on i.e. Scrublet scores.
-    Inspired by Pijuan-Sala et al. Nature 2019 and Popescu et al. Nature 2019.
+    """Infer doublets based on Scrublet scores.
+
+    This implementation is inspired by [Pijuan-Sala19]_ and [Popescu19]_.
 
     Parameters
     ----------
@@ -303,7 +308,9 @@ def mark_singlets(
     demux_attr: Optional[str] = 'demux_type',
     dbl_clusts: Optional[str] = None,
 ) -> None:
-    """Convert doublet prediction into doublet annotations that Pegasus can recognize. Must run infer_doublets first.
+    """Convert doublet prediction into doublet annotations that Pegasus can recognize.
+
+    Must run ``infer_doublets`` first.
 
     Parameters
     ----------

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requires = [
     "scikit-learn>=0.23.2",
     "scikit-misc",
     "scipy",
+    "scrublet",
     "seaborn",
     "setuptools",
     "statsmodels",


### PR DESCRIPTION
* `run_scrublet` function in `tools/doublet_detection.py`.
* Add references of `run_scrublet`, `infer_doublets`, and `mark_singlets`.
* Add these 3 functions to `api/index.rst`.
* Add `scrublet` to Pegasus dependencies.