### PR TITLE
Fix bug on PCA using batch-corrected count matrix

### DIFF
--- a/pegasus/tools/batch_correction.py
+++ b/pegasus/tools/batch_correction.py
@@ -174,7 +174,7 @@ def correct_batch(data: MultimodalData, features: str = None) -> None:
     logger.info("Adjustment parameters are estimated.")
 
     # select dense matrix
-    keyword = select_features(data, features = features, standardize = False, max_value = None) # do not standardize or truncate max_value
+    keyword = select_features(data, features=features, standardize=False, max_value=None, use_cache=False) # do not standardize or truncate max_value
     logger.info("Features are selected.")
 
     if can_correct:
@@ -313,7 +313,7 @@ def run_scanorama(
     logger.info("Start integration using Scanorama.")
 
     rep = 'scanorama'
-    keyword = select_features(data, features = features, standardize = standardize, max_value = max_value)
+    keyword = select_features(data, features=features, standardize=standardize, max_value=max_value, use_cache=False)
     X = data.uns[keyword]
 
     datasets = []


### PR DESCRIPTION
* Add `use_cache` option to `select_features` function. Only subset count matrix if `use_cache=False`, or `use_cache=True` and `data.uns[keyword]` doesn't exist.
* Add `use_cache` option to `pca` to decide whether to use precalculated subset count matrix or not. Default is `True`.
* Both `correct_batch` and `run_scanorama` don't use precalculated subset count matrix (`use_cache=False`) in `select_features` step.