### PR TITLE
Update dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,5 @@ seaborn
 setuptools
 statsmodels
 torch
-umap-learn>=0.4
+umap-learn>=0.4, <0.5
 xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ numba
 numpy
 pandas>=0.24
 pegasusio>=0.2.9
-pyarrow
 pybind11
 python-igraph
 scanorama
@@ -30,5 +29,4 @@ setuptools
 statsmodels
 torch
 umap-learn>=0.4
-xlrd
 xlsxwriter


### PR DESCRIPTION
* Retrict `umap-learn` version: Enforce using v0.4. v0.5 has API changes which would result in crashes.
* Remove`pyarrow`: It is now only required by [Cirrocumulus](https://github.com/klarman-cell-observatory/cirrocumulus/blob/master/requirements.txt), as parquet-format file generation has been moved there.
* Remove `xlrd`: It is no longer used in Pegasus.