### PR TITLE
bug fix

### DIFF
--- a/pegasus/pipeline/pipeline.py
+++ b/pegasus/pipeline/pipeline.py
@@ -276,7 +276,7 @@ def analyze_one_modality(unidata: UnimodalData, output_name: str, is_raw: bool, 
         if clust_attr is not None:
             logger.info(f"For doublet inference, clust_attr={clust_attr}.")
 
-        tools.infer_doublets(unidata, channel_attr = channel_attr, clust_attr = clust_attr, expected_doublet_rate = kwargs["expected_doublet_rate"], robust = True, n_jobs = kwargs["n_jobs"], random_state = kwargs["random_state"], plot_hist = output_name)
+        tools.infer_doublets(unidata, channel_attr = channel_attr, clust_attr = clust_attr, expected_doublet_rate = kwargs["expected_doublet_rate"], n_jobs = kwargs["n_jobs"], random_state = kwargs["random_state"], plot_hist = output_name)
         
         dbl_clusts = None
         if clust_attr is not None:

--- a/pegasus/tools/signature_score.py
+++ b/pegasus/tools/signature_score.py
@@ -161,6 +161,8 @@ def calc_signature_score(
         sig_string = signatures
         if sig_string in predefined_signatures:
             signatures = _load_signatures_from_file(predefined_signatures[sig_string])
+            from threadpoolctl import threadpool_limits
+            
             if sig_string.startswith("cell_cycle"):
                 _calc_sig_scores(data, signatures, show_omitted_genes = show_omitted_genes)
                 data.obs["cycle_diff"] = data.obs["G2/M"] - data.obs["G1/S"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ docopt
 demuxEM
 forceatlas2-python
 gprofiler-official
-harmony-pytorch
+harmony-pytorch>=0.1.6
 hnswlib
 importlib_metadata>=0.7; python_version < '3.8'
 psutil

--- a/tests/run_one_sample.sh
+++ b/tests/run_one_sample.sh
@@ -1,1 +1,1 @@
-pegasus cluster -p 2 --min-genes 500 --max-genes 6000 --percent-mito 20.0 --output-filtration-results --output-h5ad --output-loom --plot-filtration-results --plot-hvf --pca-robust --louvain --leiden --tsne --umap --fle tests/data/heart_1k_v3/filtered_feature_bc_matrix.h5 tests/one_sample_result
+pegasus cluster -p 2 --min-genes 500 --max-genes 6000 --percent-mito 20.0 --output-filtration-results --output-h5ad --output-loom --plot-filtration-results --plot-hvf --louvain --leiden --tsne --umap --fle tests/data/heart_1k_v3/filtered_feature_bc_matrix.h5 tests/one_sample_result

--- a/tests/run_pipeline.sh
+++ b/tests/run_pipeline.sh
@@ -1,5 +1,5 @@
 pegasus aggregate_matrix tests/data/count_matrix.csv tests/aggr
-pegasus cluster -p 2 --min-genes 500 --max-genes 6000 --percent-mito 20.0 --output-filtration-results --output-h5ad --output-loom --plot-filtration-results --plot-hvf --correct-batch-effect --pca-robust --louvain --leiden --tsne --umap --fle --infer-doublets --dbl-cluster-attr louvain_labels tests/aggr.zarr.zip tests/result
+pegasus cluster -p 2 --min-genes 500 --max-genes 6000 --percent-mito 20.0 --output-filtration-results --output-h5ad --output-loom --plot-filtration-results --plot-hvf --correct-batch-effect --louvain --leiden --tsne --umap --fle --infer-doublets --dbl-cluster-attr louvain_labels tests/aggr.zarr.zip tests/result
 pegasus de_analysis -p 2 --labels louvain_labels --t --fisher tests/result.zarr.zip tests/result.de.xlsx
 pegasus annotate_cluster --markers mouse_immune,mouse_brain tests/result.zarr.zip tests/result.anno.txt
 pegasus plot compo --groupby leiden_labels --condition Channel tests/result.zarr.zip tests/result.compo.pdf


### PR DESCRIPTION
* Fix lint issue in pull request #150 .
* Remove `--pca-robust` from test scripts.
* Remove `robust=True` in calls of function `infer_doublets` in `pipeline/pipeline.py`.
* Enforce `harmony-pytorch` v0.1.6 in dependencies to fit the API of `run_harmony` function.