### PR TITLE
Fix bug when generating h5ad output

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -49,3 +49,7 @@ jobs:
       run: |
         bash tests/run_hashing_citeseq.sh
         pytest tests/test_hashing_citeseq.py
+    - name: iNMF test
+      run: |
+        bash tests/run_inmf.sh
+        pytest tests/test_inmf.py

--- a/pegasus/pipeline/pipeline.py
+++ b/pegasus/pipeline/pipeline.py
@@ -384,9 +384,10 @@ def analyze_one_modality(unidata: UnimodalData, output_name: str, is_raw: bool, 
             unidata_copy.uns['Vs'] = np.array(unidata_copy.uns['Vs'])
         adata = unidata_copy.to_anndata()
         del unidata_copy
+        adata.var[['highly_variable_features', 'robust']] = adata.var[['highly_variable_features', 'robust']].fillna(value=False)
         if "_tmp_fmat_highly_variable_features" in adata.uns:
             adata.uns["scale.data"] = adata.uns.pop("_tmp_fmat_highly_variable_features")  # assign by reference
-            adata.uns["scale.data.rownames"] = unidata.var_names[unidata.var["highly_variable_features"]].values
+            adata.uns["scale.data.rownames"] = unidata.var_names[unidata.var["highly_variable_features"]==True].values
         adata.write(f"{output_name}.h5ad", compression="gzip")
         del adata
         end_time = time.perf_counter()

--- a/pegasus/pipeline/pipeline.py
+++ b/pegasus/pipeline/pipeline.py
@@ -378,9 +378,15 @@ def analyze_one_modality(unidata: UnimodalData, output_name: str, is_raw: bool, 
     if kwargs["output_h5ad"]:
         import time
         start_time = time.perf_counter()
-        adata = unidata.to_anndata()
-        adata.uns["scale.data"] = adata.uns.pop("_tmp_fmat_highly_variable_features")  # assign by reference
-        adata.uns["scale.data.rownames"] = unidata.var_names[unidata.var["highly_variable_features"]].values
+        unidata_copy = unidata.copy()
+        if kwargs["batch_correction"] and kwargs["correction_method"] == "inmf":
+            unidata_copy.uns['Hs'] = np.concatenate(unidata_copy.uns['Hs'])
+            unidata_copy.uns['Vs'] = np.array(unidata_copy.uns['Vs'])
+        adata = unidata_copy.to_anndata()
+        del unidata_copy
+        if "_tmp_fmat_highly_variable_features" in adata.uns:
+            adata.uns["scale.data"] = adata.uns.pop("_tmp_fmat_highly_variable_features")  # assign by reference
+            adata.uns["scale.data.rownames"] = unidata.var_names[unidata.var["highly_variable_features"]].values
         adata.write(f"{output_name}.h5ad", compression="gzip")
         del adata
         end_time = time.perf_counter()

--- a/pegasus/tools/nmf.py
+++ b/pegasus/tools/nmf.py
@@ -380,12 +380,6 @@ def integrative_nmf(
 
     Xs = _select_and_scale_features(data, features=features, space=space, batch=batch)
 
-    np.save('counts.npy', np.concatenate(Xs).astype(np.float64))
-
-    # _end = time.perf_counter()
-    # print(f"Scale X: {_end-_start:.6f}s.")
-    # _start = _end
-
     try:
         from nmf import integrative_nmf
     except ImportError as e:
@@ -407,10 +401,6 @@ def integrative_nmf(
         lam=lam,
         fp_precision=fp_precision,
     )
-
-    # _end = time.perf_counter()
-    # print(f"INMF: {_end-_start:.6f}s.")
-    # _start = _end
 
     # Implementation of algo 3, quantile normalization
     Hs_new = numbaList()
@@ -438,15 +428,8 @@ def integrative_nmf(
             max_size = H_new.shape[0]
             ref_batch = i
 
-    # _end = time.perf_counter()
-    # print(f"Scale H and cluster: {_end-_start:.6f}s.")
-    # _start = _end
-
     if quantile_norm:
         _quantile_norm(Hs_new, csums, ids_by_clusts, nbatch, ref_batch, n_components) # quantile normalization
-
-    # _end = time.perf_counter()
-    # print(f"Quantile: {_end-_start:.6f}s.")
 
     data.uns["inmf_features"] = features # record which feature to use
     data.uns["W"] = np.ascontiguousarray(W.T, dtype=np.float32)  # cannot be varm because numbers of features are not the same

--- a/tests/run_inmf.sh
+++ b/tests/run_inmf.sh
@@ -1,0 +1,2 @@
+pegasus aggregate_matrix tests/data/count_matrix.csv tests/aggr
+pegasus cluster -p 2 --output-h5ad --output-loom --correct-batch-effect --correction-method inmf --louvain --umap tests/aggr.zarr.zip tests/inmf_result

--- a/tests/run_pipeline.sh
+++ b/tests/run_pipeline.sh
@@ -1,5 +1,5 @@
 pegasus aggregate_matrix tests/data/count_matrix.csv tests/aggr
-pegasus cluster -p 2 --min-genes 500 --max-genes 6000 --percent-mito 20.0 --output-filtration-results --output-h5ad --output-loom --plot-filtration-results --plot-hvf --correct-batch-effect --louvain --leiden --tsne --umap --fle --infer-doublets --dbl-cluster-attr louvain_labels tests/aggr.zarr.zip tests/result
+pegasus cluster -p 2 --min-genes 500 --max-genes 6000 --percent-mito 20.0 --output-filtration-results --output-h5ad --output-loom --plot-filtration-results --plot-hvf --correct-batch-effect --nmf --louvain --leiden --tsne --umap --fle --infer-doublets --dbl-cluster-attr louvain_labels tests/aggr.zarr.zip tests/result
 pegasus de_analysis -p 2 --labels louvain_labels --t --fisher tests/result.zarr.zip tests/result.de.xlsx
 pegasus annotate_cluster --markers mouse_immune,mouse_brain tests/result.zarr.zip tests/result.anno.txt
 pegasus plot compo --groupby leiden_labels --condition Channel tests/result.zarr.zip tests/result.compo.pdf

--- a/tests/test_inmf.py
+++ b/tests/test_inmf.py
@@ -1,0 +1,47 @@
+import unittest
+
+import numpy as np
+
+class TestINMF(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestINMF, self).__init__(*args, **kwargs)
+        self.n_cells = 1043
+        self.n_features = 18952
+        self.n_hvfs = 2000
+        self.n_factors = 20
+        self.n_batches = 2
+
+    def test_h5ad(self):
+        from anndata import read_h5ad
+        adata = read_h5ad("tests/inmf_result.mm10-rna.h5ad")
+
+        self.assertEqual(adata.shape, (self.n_cells, self.n_features), "Count matrix shape not correct!")
+        self.assertEqual(adata.uns['Hs'].shape, (self.n_cells, self.n_factors), "Hs shape not correct!")
+        self.assertEqual(adata.uns['Vs'].shape, (self.n_batches, self.n_factors, self.n_hvfs), "Vs shape not correct!")
+        self.assertEqual(adata.uns['W'].shape, (self.n_hvfs, self.n_factors), "W shape not correct!")
+        self.assertEqual(adata.obsm['X_inmf'].shape, (self.n_cells, self.n_factors), "iNMF embedding shape not correct!")
+
+    def test_loom(self):
+        import loompy
+        with loompy.connect("tests/inmf_result.mm10-rna.loom") as ds:
+            self.assertEqual(ds.shape, (self.n_features, self.n_cells), "Count matrix shape not correct!")
+            self.assertEqual(ds.ca['X_inmf'].shape, (self.n_cells, self.n_factors), "iNMF embedding shape not correct!")
+
+    def test_zarr(self):
+        import pegasusio as io
+        data = io.read_input("tests/inmf_result.zarr.zip")
+
+        self.assertEqual(data.shape, (self.n_cells, self.n_features), "Count matrix shape not correct!")
+
+        self.assertEqual(len(data.uns['Hs']), self.n_batches, "The Hs list is not complete!")
+        self.assertEqual(np.concatenate(data.uns['Hs']).shape, (self.n_cells, self.n_factors), "Hs shape not correct!")
+
+        self.assertEqual(len(data.uns['Vs']), self.n_batches, "The Vs list is not complete!")
+        for i in range(len(data.uns['Vs'])):
+            self.assertEqual(data.uns['Vs'][i].shape, (self.n_factors, self.n_hvfs), f"V[{i}] has incorrect shape {data.uns['Vs'][i].shape}!")
+
+        self.assertEqual(data.obsm['X_inmf'].shape, (self.n_cells, self.n_factors), "iNMF embedding shape not correct!")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* When `--output-h5ad` option in `pegasus cluster` command is enabled, do the following:
  * Merge the list `data.uns['Hs']` into one numpy array of shape `(n_cells, n_factors)` using `np.concatenate`, as otherwise `h5py` won't accept, and each array in the list has different shape;
  * Merge the list `data.uns['Vs']` into one numpy array of shape `(n_batches, n_factors, n_hvfs)` using `np.array`, as otherwise `h5py` won't accept.
  * No scaled counts as there is no `data.uns['_fmt_fmat_highly_variable_features']` in the result.
* In `integrative_nmf` function, remove intermediate output and commented benchmark code.
* Add CI test for iNMF and NMF.
* When `--citeseq` option in `pegasus cluster` command is enabled:
  * `'highly_variable_features'` and `'robust'` attributes in `unidata.var` contain `NaN` values, which makes the writing to `h5ad` fail.
  * Use `fillna` function to set those NaN values to `False`. However, there might be a more systematic way to fix this issue.