### PR TITLE
Add spatial plot function for 10X Visium data

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -142,6 +142,7 @@ Plotting
 
     scatter
     scatter_groups
+    spatial
     compo_plot
     violin
     heatmap

--- a/pegasus/__init__.py
+++ b/pegasus/__init__.py
@@ -77,6 +77,7 @@ from .plotting import (
     scatter,
     compo_plot,
     scatter_groups,
+    scatter_spatial,
     violin,
     heatmap,
     dotplot,

--- a/pegasus/__init__.py
+++ b/pegasus/__init__.py
@@ -75,7 +75,7 @@ from .plotting import (
     scatter,
     compo_plot,
     scatter_groups,
-    scatter_spatial,
+    spatial,
     violin,
     heatmap,
     dotplot,

--- a/pegasus/plotting/__init__.py
+++ b/pegasus/plotting/__init__.py
@@ -2,6 +2,7 @@ from .plot_library import (
     scatter,
     compo_plot,
     scatter_groups,
+    scatter_spatial,
     violin,
     heatmap,
     dotplot,

--- a/pegasus/plotting/__init__.py
+++ b/pegasus/plotting/__init__.py
@@ -2,7 +2,7 @@ from .plot_library import (
     scatter,
     compo_plot,
     scatter_groups,
-    scatter_spatial,
+    spatial,
     violin,
     heatmap,
     dotplot,

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -30,7 +30,7 @@ from .plot_utils import (
     DictWithDefault,
     _generate_categories,
     _plot_corners,
-    _plot_circles,
+    _plot_spots,
 )
 
 
@@ -227,7 +227,7 @@ def scatter(
                             rasterized=True,
                         )
                     else:
-                        img = _plot_circles(
+                        img = _plot_spots(
                             x[selected]*scale_factor if scale_factor is not None else x[selected],
                             y[selected]*scale_factor if scale_factor is not None else y[selected],
                             c=values[selected],
@@ -280,7 +280,7 @@ def scatter(
                                         **scatter_kwargs,
                                     )
                                 else:
-                                    _plot_circles(
+                                    _plot_spots(
                                         x[idx]*scale_factor if scale_factor is not None else x[idx],
                                         y[idx]*scale_factor if scale_factor is not None else y[idx],
                                         c=palette[k],

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -112,7 +112,7 @@ def scatter(
     marker_size: ``float``, optional (default: ``None``)
         Manually set the marker size in the plot. If ``None``, automatically adjust the marker size to the plot size.
     scale_factor: ``float``, optional (default: ``None``)
-        Manually set the scale factor in the plot if it's not ``None``.
+        Manually set the scale factor in the plot if it's not ``None``. This is used by generating the spatial plots for 10x Visium data.
     return_fig: ``bool``, optional, default: ``False``
         Return a ``Figure`` object if ``True``; return ``None`` otherwise.
     dpi: ``float``, optional, default: 300.0
@@ -212,10 +212,10 @@ def scatter(
                     if fix_corners:
                         _plot_corners(ax, corners, local_marker_size)
 
-                    if marker_size is None:
+                    if scale_factor is None:
                         img = ax.scatter(
-                            x[selected]*scale_factor if scale_factor is not None else x[selected],
-                            y[selected]*scale_factor if scale_factor is not None else y[selected],
+                            x[selected],
+                            y[selected],
                             c=values[selected],
                             s=local_marker_size,
                             marker=".",
@@ -228,8 +228,8 @@ def scatter(
                         )
                     else:
                         img = _plot_spots(
-                            x[selected]*scale_factor if scale_factor is not None else x[selected],
-                            y[selected]*scale_factor if scale_factor is not None else y[selected],
+                            x[selected] * scale_factor,
+                            y[selected] * scale_factor,
                             c=values[selected],
                             s=local_marker_size,
                             alpha=alpha[pos],
@@ -264,13 +264,13 @@ def scatter(
                             scatter_kwargs = {"alpha": alpha[pos], "edgecolors": "none", "rasterized": True}
 
                             if cat != "":
-                                if (legend_loc[pos] != "on data") and (marker_size is None):
+                                if (legend_loc[pos] != "on data") and (scale_factor is None):
                                     scatter_kwargs["label"] = cat
                                 else:
                                     text_list.append((np.median(x[idx]), np.median(y[idx]), cat))
 
                             if cat != "" or (cat == "" and show_background):
-                                if marker_size is None:
+                                if scale_factor is None:
                                     ax.scatter(
                                         x[idx],
                                         y[idx],
@@ -281,8 +281,8 @@ def scatter(
                                     )
                                 else:
                                     _plot_spots(
-                                        x[idx]*scale_factor if scale_factor is not None else x[idx],
-                                        y[idx]*scale_factor if scale_factor is not None else y[idx],
+                                        x[idx] * scale_factor,
+                                        y[idx] * scale_factor,
                                         c=palette[k],
                                         s=local_marker_size,
                                         ax=ax,
@@ -294,7 +294,7 @@ def scatter(
 
                     if attr != '_all':
                         if legend_loc[pos] == "right margin":
-                            if marker_size is not None:
+                            if scale_factor is not None:
                                 for k, cat in enumerate(labels.categories):
                                     ax.scatter([], [], c=palette[k], label=cat)
                             legend = ax.legend(
@@ -586,7 +586,10 @@ def spatial(
     basis: str = 'spatial',
     resolution: str = 'hires',
     cmaps: Optional[Union[str, List[str]]] = 'viridis',
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
     alpha: Union[float, List[float]] = 1.0,
+    alpha_img: float = 1.0,
     dpi: float = 300.0,
     return_fig: bool = False,
     **kwargs,
@@ -609,7 +612,9 @@ def spatial(
     cmaps: ``str`` or ``List[str]``, optional, default: ``viridis``
         The colormap(s) for plotting numeric attributes. The default ``viridis`` colormap theme follows the spatial plot function in SCANPY (``scanpy.pl.spatial``).
     alpha: ``float`` or ``List[float]``, optional, default: ``1.0``
-        Alpha value for blending, from 0.0 (transparent) to 1.0 (opaque).
+        Alpha value for blending the attribute layers, from 0.0 (transparent) to 1.0 (opaque). If this is a list, the length must match attrs, which means we set a separate alpha value for each attribute.
+    alpha_img: ``float``, optional, default: ``1.0``
+        Alpha value for blending the background spatial image, from 0.0 (transparent) to 1.0 (opaque).
     dpi: ``float``, optional, default: ``300.0``
         The resolution of the figure in dots-per-inch.
     return_fig: ``bool``, optional, default: ``False``
@@ -646,15 +651,16 @@ def spatial(
         marker_size=spot_radius,
         scale_factor=scale_factor,
         cmaps=cmaps,
+        vmin=vmin,
+        vmax=vmax,
         dpi=dpi,
         alpha=alpha,
         return_fig=True,
-        **kwargs,
     )
 
     for i in range(nattrs):
         ax = fig.axes[i]
-        ax.imshow(image_obj, alpha=alpha)
+        ax.imshow(image_obj, alpha=alpha_img)
 
     return fig if return_fig else None
 

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -662,13 +662,18 @@ def spatial(
         return_fig=True,
     )
 
-    coord_x = fig.axes[0].get_xlim()
-    coord_y = fig.axes[0].get_ylim()
+    coord_x = (data.obsm[f"X_{basis}"][:, 0].min() * scale_factor,
+               data.obsm[f"X_{basis}"][:, 0].max() * scale_factor)
+    coord_y = (data.obsm[f"X_{basis}"][:, 1].min() * scale_factor,
+               data.obsm[f"X_{basis}"][:, 1].max() * scale_factor)
+
+    margin_offset = 50
+
     for i in range(nattrs):
         ax = fig.axes[i]
         ax.imshow(image_obj, alpha=alpha_img)
-    fig.axes[0].set_xlim(coord_x[0], coord_x[1])
-    fig.axes[0].set_ylim(coord_y[1], coord_y[0])
+        ax.set_xlim(coord_x[0]-margin_offset, coord_x[1]+margin_offset)
+        ax.set_ylim(coord_y[1]+margin_offset, coord_y[0]-margin_offset)
 
     return fig if return_fig else None
 

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -225,7 +225,6 @@ def scatter(
                             vmin=vmin,
                             vmax=vmax,
                             rasterized=True,
-                            **kwargs,
                         )
                     else:
                         img = _plot_circles(

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -662,9 +662,13 @@ def spatial(
         return_fig=True,
     )
 
+    coord_x = fig.axes[0].get_xlim()
+    coord_y = fig.axes[0].get_ylim()
     for i in range(nattrs):
         ax = fig.axes[i]
         ax.imshow(image_obj, alpha=alpha_img)
+    fig.axes[0].set_xlim(coord_x[0], coord_x[1])
+    fig.axes[0].set_ylim(coord_y[1], coord_y[0])
 
     return fig if return_fig else None
 

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -279,7 +279,6 @@ def scatter(
                                         s=local_marker_size,
                                         marker=".",
                                         **scatter_kwargs,
-                                        **kwargs,
                                     )
                                 else:
                                     _plot_circles(
@@ -289,7 +288,6 @@ def scatter(
                                         s=local_marker_size,
                                         ax=ax,
                                         **scatter_kwargs,
-                                        **kwargs,
                                     )
                             else:
                                 if fix_corners:

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -305,7 +305,7 @@ def scatter(
                                 ncol=_get_legend_ncol(label_size, legend_ncol),
                             )
                             for handle in legend.legendHandles:
-                                handle.set_sizes([300.0 if marker_size is None else 100.0])
+                                handle.set_sizes([300.0 if scale_factor is None else 100.0])
                         elif legend_loc[pos] == "on data":
                             texts = []
                             for px, py, txt in text_list:
@@ -611,6 +611,10 @@ def spatial(
         For 10X Visium data, user can either specify ``hires`` or ``lowres`` to use High or Low resolution spatial images, respectively.
     cmaps: ``str`` or ``List[str]``, optional, default: ``viridis``
         The colormap(s) for plotting numeric attributes. The default ``viridis`` colormap theme follows the spatial plot function in SCANPY (``scanpy.pl.spatial``).
+    vmin: ``float``, optional, default: ``None``
+        Minimum value to show on a numeric scatter plot (feature plot).
+    vmax: ``float``, optional, default: ``None``
+        Maximum value to show on a numeric scatter plot (feature plot).
     alpha: ``float`` or ``List[float]``, optional, default: ``1.0``
         Alpha value for blending the attribute layers, from 0.0 (transparent) to 1.0 (opaque). If this is a list, the length must match attrs, which means we set a separate alpha value for each attribute.
     alpha_img: ``float``, optional, default: ``1.0``

--- a/pegasus/plotting/plot_utils.py
+++ b/pegasus/plotting/plot_utils.py
@@ -420,10 +420,10 @@ def _plot_corners(ax: Axes, corners: np.ndarray, marker_size: float) -> None:
         rasterized=True,
     )
 
-def _plot_spots(x: np.ndarray, y: np.ndarray, c: Union[str, np.ndarray], s: float, vmin: float = None, vmax: float = None, ax: Axes, **kwargs) -> PatchCollection:
-    """
-    This function is simplified from https://github.com/theislab/scanpy/blob/0dfd353abd968f3ecaafd5fac77a50a7e0dd87ee/scanpy/plotting/_utils.py#L1063-L1117,
-    which originates from: https://gist.github.com/syrte/592a062c562cd2a98a83. The original code at gist is under [The BSD 3-Clause License] (http://opensource.org/licenses/BSD-3-Clause).
+def _plot_spots(x: np.ndarray, y: np.ndarray, c: Union[str, np.ndarray], s: float, ax: Axes, vmin: float = None, vmax: float = None, **kwargs) -> PatchCollection:
+    """This function is simplified from https://github.com/theislab/scanpy/blob/0dfd353abd968f3ecaafd5fac77a50a7e0dd87ee/scanpy/plotting/_utils.py#L1063-L1117,
+    which originates from: https://gist.github.com/syrte/592a062c562cd2a98a83.
+    The original code at gist is under `The BSD 3-Clause License <http://opensource.org/licenses/BSD-3-Clause>`_.
 
     x, y: coordinates; c: either a string representing one color or an array of real values for cmap; s: spot radius; vmin, vmax: colormap lower/upper limits; kwargs: all other parameters.
     """

--- a/pegasus/plotting/plot_utils.py
+++ b/pegasus/plotting/plot_utils.py
@@ -417,3 +417,54 @@ def _plot_corners(ax: Axes, corners: np.ndarray, marker_size: float) -> None:
         edgecolors="none",
         rasterized=True,
     )
+
+def _plot_circles(x, y, c, s, ax, vmin=None, vmax=None, **kwargs):
+    """
+    This function is take from https://github.com/theislab/scanpy/blob/0dfd353abd968f3ecaafd5fac77a50a7e0dd87ee/scanpy/plotting/_utils.py#L1063-L1117,
+    which originates from here: https://gist.github.com/syrte/592a062c562cd2a98a83.
+    This function aims to making scatter plot of circle markers, with size of circles defined in data scale.
+
+    Parameters
+    ----------
+    x, y: scalar or array_like, shape (n, )
+        2-D coordinates of data points.
+    c: color or sequence of color
+        `c` can be a single color format string, or a sequence of color
+        specifications of length `N`, or a sequence of `N` numbers to be
+        mapped to colors using the `cmap` and `norm` specified via kwargs.
+        Note that `c` should not be a single numeric RGB or RGBA sequence
+        because that is indistinguishable from an array of values
+        to be colormapped. (If you insist, use `color` instead.)
+        `c` can be a 2-D array in which the rows are RGB or RGBA, however.
+    s: scalar or array_like, shape (n, )
+        Radius of circles.
+    ax: `matplotlib.axes.Axes`
+        The Axes object to which the generated PatchCollection is attached.
+    vmin, vmax : scalar, optional, default: None
+        `vmin` and `vmax` are the norm limits for image scaling.
+        If either are `None`, the min and max of the color array is used.
+    kwargs : `matplotlib.collections.Collection` properties
+        Eg. alpha, edgecolor(ec), facecolor(fc), linewidth(lw), linestyle(ls),
+        norm, cmap, transform, etc.
+    License
+    --------
+    This code is under [The BSD 3-Clause License]
+    (http://opensource.org/licenses/BSD-3-Clause)
+    """
+
+    from matplotlib.patches import Circle
+    from matplotlib.collections import PatchCollection
+
+    patches = [Circle((x_, y_), s_) for x_, y_, s_ in np.broadcast(x, y, s)]
+    collection = PatchCollection(patches, **kwargs)
+    if isinstance(c, np.ndarray) and np.issubdtype(c.dtype, np.number):
+        # Numeric
+        collection.set_array(np.ma.masked_invalid(c))
+        collection.set_clim(vmin, vmax)
+    else:
+        # Categorical
+        collection.set_facecolor(c)
+
+    ax.add_collection(collection)
+
+    return collection

--- a/pegasus/plotting/plot_utils.py
+++ b/pegasus/plotting/plot_utils.py
@@ -6,6 +6,8 @@ from typing import List, Union, Tuple
 from pegasusio import MultimodalData, UnimodalData
 from anndata import AnnData
 from matplotlib.axes import Axes
+from matplotlib.patches import Circle
+from matplotlib.collections import PatchCollection
 
 
 def _transform_basis(basis: str) -> str:
@@ -418,53 +420,18 @@ def _plot_corners(ax: Axes, corners: np.ndarray, marker_size: float) -> None:
         rasterized=True,
     )
 
-def _plot_circles(x, y, c, s, ax, vmin=None, vmax=None, **kwargs):
+def _plot_spots(x: np.ndarray, y: np.ndarray, c: Union[str, np.ndarray], s: float, vmin: float = None, vmax: float = None, ax: Axes, **kwargs) -> PatchCollection:
     """
-    This function is take from https://github.com/theislab/scanpy/blob/0dfd353abd968f3ecaafd5fac77a50a7e0dd87ee/scanpy/plotting/_utils.py#L1063-L1117,
-    which originates from here: https://gist.github.com/syrte/592a062c562cd2a98a83.
-    This function aims to making scatter plot of circle markers, with size of circles defined in data scale.
+    This function is simplified from https://github.com/theislab/scanpy/blob/0dfd353abd968f3ecaafd5fac77a50a7e0dd87ee/scanpy/plotting/_utils.py#L1063-L1117,
+    which originates from: https://gist.github.com/syrte/592a062c562cd2a98a83. The original code at gist is under [The BSD 3-Clause License] (http://opensource.org/licenses/BSD-3-Clause).
 
-    Parameters
-    ----------
-    x, y: scalar or array_like, shape (n, )
-        2-D coordinates of data points.
-    c: color or sequence of color
-        `c` can be a single color format string, or a sequence of color
-        specifications of length `N`, or a sequence of `N` numbers to be
-        mapped to colors using the `cmap` and `norm` specified via kwargs.
-        Note that `c` should not be a single numeric RGB or RGBA sequence
-        because that is indistinguishable from an array of values
-        to be colormapped. (If you insist, use `color` instead.)
-        `c` can be a 2-D array in which the rows are RGB or RGBA, however.
-    s: scalar or array_like, shape (n, )
-        Radius of circles.
-    ax: `matplotlib.axes.Axes`
-        The Axes object to which the generated PatchCollection is attached.
-    vmin, vmax : scalar, optional, default: None
-        `vmin` and `vmax` are the norm limits for image scaling.
-        If either are `None`, the min and max of the color array is used.
-    kwargs : `matplotlib.collections.Collection` properties
-        Eg. alpha, edgecolor(ec), facecolor(fc), linewidth(lw), linestyle(ls),
-        norm, cmap, transform, etc.
-    License
-    --------
-    This code is under [The BSD 3-Clause License]
-    (http://opensource.org/licenses/BSD-3-Clause)
+    x, y: coordinates; c: either a string representing one color or an array of real values for cmap; s: spot radius; vmin, vmax: colormap lower/upper limits; kwargs: all other parameters.
     """
-
-    from matplotlib.patches import Circle
-    from matplotlib.collections import PatchCollection
-
-    patches = [Circle((x_, y_), s_) for x_, y_, s_ in np.broadcast(x, y, s)]
-    collection = PatchCollection(patches, **kwargs)
-    if isinstance(c, np.ndarray) and np.issubdtype(c.dtype, np.number):
-        # Numeric
-        collection.set_array(np.ma.masked_invalid(c))
-        collection.set_clim(vmin, vmax)
+    spots = PatchCollection([Circle((x_, y_), s_) for x_, y_, s_ in np.broadcast(x, y, s)], **kwargs)
+    if isinstance(c, str):
+        spots.set_facecolor(c)
     else:
-        # Categorical
-        collection.set_facecolor(c)
-
-    ax.add_collection(collection)
-
-    return collection
+        spots.set_array(c)
+        spots.set_clim(vmin, vmax)
+    ax.add_collection(spots)
+    return spots


### PR DESCRIPTION
Function `spatial` defined in `plotting.plot_library`.

Besides, the following modifications are applied accordingly:
* Add `_plot_spots` function in `plotting.plot_utils` to make scatter plot with point circle size being data-specific.
* Add `marker_size` and `scale_factor` arguments to function `scatter` function in `plotting.plot_library`:
  * `spatial` function sets `marker_size` and `scale_factor` based on the spatial image to use as the background.
  * Use `_plot_spots` instead of `matplotlib.pyplot.scatter` for spatial plots.
  * For general scatter plots, both arguments are `None`.
* 