### PR TITLE
Enforce recalculating kNN for subclustering

### DIFF
--- a/pegasus/tools/clustering.py
+++ b/pegasus/tools/clustering.py
@@ -681,7 +681,7 @@ def split_one_cluster(
     idx = np.where(data.obs[clust_label] == clust_id)[0]
     tmpdat = data[idx].copy()
     from pegasus.tools import neighbors
-    neighbors(tmpdat, rep=rep)
+    neighbors(tmpdat, rep=rep, use_cache=False)
     leiden(tmpdat, rep=rep, resolution=None, n_clust=n_clust, random_state=random_state)
     new_clust = data.obs[clust_label].values.astype(int)
     new_label = new_clust.max() + 1


### PR DESCRIPTION
A small bug fix for `split_one_cluster` function.