### PR TITLE
Improve plotting functions

### DIFF
--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -31,6 +31,7 @@ from .plot_utils import (
     _generate_categories,
     _plot_corners,
     _plot_spots,
+    _get_valid_attrs,
 )
 
 
@@ -153,23 +154,7 @@ def scatter(
         attrs = [attrs]
 
     # Select only valid attributes
-    attrs_filt = []
-    attrs_drop = []
-    for attr in attrs:
-        if (attr == '_all') or (attr in data.obs) or (attr in data.var_names) or ('@' in attr):
-            if not '@' in attr:
-                attrs_filt.append(attr)
-            else:
-                obsm_key, sep, component = attr.partition("@")
-                if (sep != "@") or (obsm_key not in data.obsm) or (not component.isdigit()):
-                    attrs_drop.append(attr)
-                else:
-                    attrs_filt.append(attr)
-        else:
-            attrs_drop.append(attr)
-    attrs = attrs_filt
-    if len(attrs_drop) > 0:
-        print(f"Warning: Attributes {attrs_drop} are not in data.obs, data.var_names or data.obsm!")
+    attrs = _get_valid_attrs(data, attrs)
 
     if isinstance(basis, str):
         basis = [basis]

--- a/pegasus/plotting/plot_library.py
+++ b/pegasus/plotting/plot_library.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import seaborn as sns
+import matplotlib
 import matplotlib.pyplot as plt
 
 from scipy.sparse import issparse
@@ -1443,7 +1444,7 @@ def dotplot(
     size_legend.grid(False)
 
     # Reset global settings.
-    sns.reset_orig()
+    matplotlib.rc_file_defaults()
 
     return fig if return_fig else None
 

--- a/pegasus/plotting/plot_utils.py
+++ b/pegasus/plotting/plot_utils.py
@@ -435,3 +435,24 @@ def _plot_spots(x: np.ndarray, y: np.ndarray, c: Union[str, np.ndarray], s: floa
         spots.set_clim(vmin, vmax)
     ax.add_collection(spots)
     return spots
+
+
+def _get_valid_attrs(data:Union[MultimodalData, UnimodalData], attrs: List[str]) -> List[str]:
+    attrs_filt = []
+    attrs_drop = []
+    for attr in attrs:
+        if (attr == '_all') or (attr in data.obs) or (attr in data.var_names) or ('@' in attr):
+            if not '@' in attr:
+                attrs_filt.append(attr)
+            else:
+                obsm_key, sep, component = attr.partition("@")
+                if (sep != "@") or (obsm_key not in data.obsm) or (not component.isdigit()):
+                    attrs_drop.append(attr)
+                else:
+                    attrs_filt.append(attr)
+        else:
+            attrs_drop.append(attr)
+    if len(attrs_drop) > 0:
+        print(f"Warning: Attributes {attrs_drop} are not in data.obs, data.var_names or data.obsm!")
+
+    return attrs_filt


### PR DESCRIPTION
Summary on fixes:

* `pegasus.scatter`: Currently, the function stops plotting once hitting an attribute not appearing in data. This PR makes it plot all available attributes, and only throw warnings for the missing attributes.
* `pegasus.dotplot`: All other plots won't be shown after the first dotplot when running in Jupyter notebook. This is caused by an incorrect function on resetting the overwritten seaborn parameters back when dotplot is finished.