### PR TITLE
Address a few frequent matrix dtype conversion errors

### DIFF
--- a/pegasus/tools/preprocessing.py
+++ b/pegasus/tools/preprocessing.py
@@ -590,8 +590,8 @@ def select_features(
         psum = np.multiply(X, X).sum(axis=0)
         std = ((psum - X.shape[0] * (m1 ** 2)) / (X.shape[0] - 1.0)) ** 0.5
         std[std == 0] = 1
-        X -= m1
-        X /= std
+        X = X - m1
+        X = X / std
         data.uns["stdzn_mean"] = m1
         data.uns["stdzn_std"] = std
         data.uns.pop(batch_ls_key, None)
@@ -723,8 +723,8 @@ def pc_transform(
     # standardization
     if "stdzn_mean" in data.uns:
         assert "stdzn_std" in data.uns
-        X -= data.uns["stdzn_mean"]
-        X /= data.uns["stdzn_std"]
+        X = X - data.uns["stdzn_mean"]
+        X = X - data.uns["stdzn_std"]
     if "stdzn_max_value" in data.uns:
         max_value = data.uns["stdzn_max_value"]
         X[X > max_value] = max_value

--- a/pegasus/tools/utils.py
+++ b/pegasus/tools/utils.py
@@ -109,6 +109,9 @@ def calc_stat_per_batch(X: Union[csr_matrix, np.ndarray], batch: Union[pd.Catego
         codes = np.array(batch, dtype = np.int32)
         nbatch = codes.max() + 1 # assume cluster label starts from 0
 
+    # Try to fix frequent dtype errors in this function by ensuring that the matrix is float32
+    X = X.astype(np.float32)
+
     if issparse(X):
         from pegasus.cylib.fast_utils import calc_stat_per_batch_sparse
         return calc_stat_per_batch_sparse(X.shape[0], X.shape[1], X.data, X.indices, X.indptr, nbatch, codes)


### PR DESCRIPTION
When running pegasus I've encountered recurrent dtype errors in the `calc_stat_per_batch` function that seem to happen when the matrix is not specifically cast to np.float32.  There are also a few cases in preprocessing.py where the use of `-=` or `/=` can cause occasional dtype errors. 