### PR TITLE
Bug fix for deseq2 function with one contrast

### DIFF
--- a/pegasus/tools/pseudobulk.py
+++ b/pegasus/tools/pseudobulk.py
@@ -275,7 +275,7 @@ def _run_pydeseq2(
     )
     dds.deseq2()
 
-    if isinstance(contrasts, str):
+    if isinstance(contrasts, Tuple):
         contrasts = [contrasts]
     if isinstance(de_key, str):
         de_key = [de_key]
@@ -338,7 +338,7 @@ def _run_rdeseq2(
 
     dds = deseq2.DESeq(dds)
 
-    if isinstance(contrasts, str):
+    if isinstance(contrasts, Tuple):
         contrasts = [contrasts]
     if isinstance(de_key, str):
         de_key = [de_key]


### PR DESCRIPTION
If one contrast is provided, its type should be `Tuple` not `str`.