### PR TITLE
Bug fix in background signature estimation

### DIFF
--- a/ext_modules/fast_utils.pyx
+++ b/ext_modules/fast_utils.pyx
@@ -250,6 +250,33 @@ cpdef calc_sig_background_sparse(int M, int N, const float[:] data, indices_type
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
+cpdef calc_sig_background_sparse_no_std(int M, int N, const float[:] data, indices_type[:] indices, indptr_type[:] indptr, int n_bins, const int[:] codes, const double[:] mean_vec):
+    cdef Py_ssize_t i, j
+
+    sig_bkg_mean = np.zeros((M, n_bins), dtype = np.float64)
+    bin_mean = np.zeros(n_bins, dtype = np.float64)
+    cdef double[:, :] sig_bkgm_view = sig_bkg_mean
+    cdef double[:] bin_mean_view = bin_mean
+
+    cdef int[:] bin_count = np.zeros(n_bins, dtype = np.int32)
+
+    for j in range(N):
+        bin_count[codes[j]] += 1
+        bin_mean_view[codes[j]] += mean_vec[j]
+
+    for i in range(M):
+        for j in range(indptr[i], indptr[i + 1]):
+            sig_bkgm_view[i, codes[indices[j]]] += data[j]
+
+    for j in range(n_bins):
+        for i in range(M):
+            sig_bkgm_view[i, j] = (sig_bkgm_view[i, j] - bin_mean_view[j]) / bin_count[j]
+
+    return sig_bkg_mean
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cpdef calc_sig_background_dense(int M, int N, const float[:, :] X, int n_bins, const int[:] codes, const double[:] mean_vec):
     cdef Py_ssize_t i, j
 
@@ -279,6 +306,32 @@ cpdef calc_sig_background_dense(int M, int N, const float[:, :] X, int n_bins, c
             sig_bkgs_view[i, j] = estd if estd > 1e-4 else 1.0
 
     return sig_bkg_mean, sig_bkg_std
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef calc_sig_background_dense_no_std(int M, int N, const float[:, :] X, int n_bins, const int[:] codes, const double[:] mean_vec):
+    cdef Py_ssize_t i, j
+
+    sig_bkg_mean = np.zeros((M, n_bins), dtype = np.float64)
+    cdef double[:, :] sig_bkgm_view = sig_bkg_mean
+
+    cdef int[:] bin_count = np.zeros(n_bins, dtype = np.int32)
+    cdef double cexpr
+
+    for j in range(N):
+        bin_count[codes[j]] += 1
+
+    for i in range(M):
+        for j in range(N):
+            cexpr = X[i, j] - mean_vec[j]
+            sig_bkgm_view[i, codes[j]] += cexpr
+
+    for j in range(n_bins):
+        for i in range(M):
+            sig_bkgm_view[i, j] /= bin_count[j]
+
+    return sig_bkg_mean
 
 
 @cython.boundscheck(False)

--- a/pegasus/tools/signature_score.py
+++ b/pegasus/tools/signature_score.py
@@ -14,8 +14,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-
-def _check_and_calc_sig_background(data: UnimodalData, n_bins: int) -> bool:
+def _check_and_calc_sig_background(data: UnimodalData, n_bins: int, standardize: bool) -> bool:
     if "mean" not in data.var:
         data.var["mean"] = calc_mean(to_csr_or_dense(data.X),axis = 0)
 
@@ -36,11 +35,14 @@ def _check_and_calc_sig_background(data: UnimodalData, n_bins: int) -> bool:
         data.var["bins"] = bins
 
         # calculate background expectations
-        data.obsm["sig_bkg_mean"], data.obsm["sig_bkg_std"] = calc_sig_background(to_csr_or_dense(data.X), bins, mean_vec)
+        data.obsm["sig_bkg_mean"], sig_bkg_std = calc_sig_background(to_csr_or_dense(data.X), bins, mean_vec, standardize=standardize)
+        if standardize:
+            data.obsm["sig_bkg_std"] = sig_bkg_std
 
     return True
 
-def _calc_sig_scores(data: UnimodalData, signatures: Dict[str, List[str]], show_omitted_genes: bool = False, skip_threshold: int = 1) -> None:
+
+def _calc_sig_scores(data: UnimodalData, signatures: Dict[str, List[str]], show_omitted_genes: bool = False, skip_threshold: int = 1, standardize: bool = True) -> None:
     for key, gene_list in signatures.items():
         genes = pd.Index(gene_list)
         idx = data.var_names.isin(genes)
@@ -59,7 +61,10 @@ def _calc_sig_scores(data: UnimodalData, signatures: Dict[str, List[str]], show_
                 logger.warning(f"Signature key {key} exists in data.obs, the existing content will be overwritten!")
 
             X = data.X[:, idx].toarray() if issparse(data.X) else data.X[:, idx]
-            data.obs[key] = ((X - data.var.loc[idx, "mean"].values - data.obsm["sig_bkg_mean"][:, data.var["bins"].cat.codes[idx]]) / data.obsm["sig_bkg_std"][:,data.var["bins"].cat.codes[idx]]).mean(axis = 1).astype(np.float32)
+            if standardize:
+                data.obs[key] = ((X - data.var.loc[idx, "mean"].values - data.obsm["sig_bkg_mean"][:, data.var["bins"].cat.codes[idx]]) / data.obsm["sig_bkg_std"][:,data.var["bins"].cat.codes[idx]]).mean(axis = 1).astype(np.float32)
+            else:
+                data.obs[key] = (X - data.var.loc[idx, "mean"].values - data.obsm["sig_bkg_mean"][:, data.var["bins"].cat.codes[idx]]).mean(axis = 1).astype(np.float32)
             data.register_attr(key, "signature")
 
 
@@ -89,7 +94,7 @@ def calculate_z_score(
     if isinstance(data, MultimodalData):
         data = data._unidata
 
-    if not _check_and_calc_sig_background(data, n_bins):
+    if not _check_and_calc_sig_background(data, n_bins, standardize=True):
         return None
 
     mat = data.X
@@ -106,6 +111,7 @@ def calc_signature_score(
     data: Union[MultimodalData, UnimodalData, anndata.AnnData],
     signatures: Union[Dict[str, List[str]], str],
     n_bins: int = 50,
+    standardize: bool = True,
     show_omitted_genes: bool = False,
     skip_threshold: int = 1,
     random_state: int = 0
@@ -140,6 +146,9 @@ def calc_signature_score(
 
     n_bins: ``int``, optional, default: 50
         Number of bins on expression levels for grouping genes.
+
+    standardize: ``bool``, optional, default: True
+        If standardize the resulting signature scores regarding bin means.
 
     show_omitted_genes: ``bool``, optional, default False
         Signature genes that are not expressed in the data will be omitted. By default, pegasus does not report which genes are omitted. If this option is turned on, report omitted genes.
@@ -180,7 +189,7 @@ def calc_signature_score(
     if isinstance(data, MultimodalData):
         data = data._unidata
 
-    if not _check_and_calc_sig_background(data, n_bins):
+    if not _check_and_calc_sig_background(data, n_bins, standardize=standardize):
         return None
 
     if isinstance(signatures, str):
@@ -230,4 +239,4 @@ def calc_signature_score(
             signatures = load_signatures_from_file(sig_string)
             _calc_sig_scores(data, signatures, show_omitted_genes=show_omitted_genes, skip_threshold=skip_threshold)
     else:
-        _calc_sig_scores(data, signatures, show_omitted_genes=show_omitted_genes, skip_threshold=skip_threshold)
+        _calc_sig_scores(data, signatures, show_omitted_genes=show_omitted_genes, skip_threshold=skip_threshold, standardize=standardize)

--- a/pegasus/tools/signature_score.py
+++ b/pegasus/tools/signature_score.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from typing import Dict, List, Union
 from sklearn.cluster import KMeans
+from scipy.sparse import issparse
 
 import anndata
 from pegasusio import UnimodalData, MultimodalData, timer
@@ -57,7 +58,8 @@ def _calc_sig_scores(data: UnimodalData, signatures: Dict[str, List[str]], show_
             if key in data.obs:
                 logger.warning(f"Signature key {key} exists in data.obs, the existing content will be overwritten!")
 
-            data.obs[key] = ((data.X[:, idx].toarray() - data.var.loc[idx, "mean"].values - data.obsm["sig_bkg_mean"][:, data.var["bins"].cat.codes[idx]]) / data.obsm["sig_bkg_std"][:,data.var["bins"].cat.codes[idx]]).mean(axis = 1).astype(np.float32)
+            X = data.X[:, idx].toarray() if issparse(data.X) else data.X[:, idx]
+            data.obs[key] = ((X - data.var.loc[idx, "mean"].values - data.obsm["sig_bkg_mean"][:, data.var["bins"].cat.codes[idx]]) / data.obsm["sig_bkg_std"][:,data.var["bins"].cat.codes[idx]]).mean(axis = 1).astype(np.float32)
             data.register_attr(key, "signature")
 
 

--- a/pegasus/tools/utils.py
+++ b/pegasus/tools/utils.py
@@ -122,7 +122,7 @@ def calc_stat_per_batch(X: Union[csr_matrix, np.ndarray], batch: Union[pd.Catego
         return calc_stat_per_batch_dense(X.shape[0], X.shape[1], X, nbatch, codes)
 
 
-def calc_sig_background(X: Union[csr_matrix, np.ndarray], bins: pd.Categorical, mean_vec: List[float]) -> Tuple[np.ndarray, np.ndarray]:
+def calc_sig_background(X: Union[csr_matrix, np.ndarray], bins: pd.Categorical, mean_vec: List[float], standardize: bool) -> Tuple[np.ndarray, np.ndarray]:
     n_bins = bins.categories.size
     codes = bins.codes.astype(np.int32)
 
@@ -132,11 +132,19 @@ def calc_sig_background(X: Union[csr_matrix, np.ndarray], bins: pd.Categorical, 
         X = X.astype(np.float32)
 
     if issparse(X):
-        from pegasus.cylib.fast_utils import calc_sig_background_sparse
-        return calc_sig_background_sparse(X.shape[0], X.shape[1], X.data, X.indices, X.indptr, n_bins, codes, mean_vec)
+        if standardize:
+            from pegasus.cylib.fast_utils import calc_sig_background_sparse
+            return calc_sig_background_sparse(X.shape[0], X.shape[1], X.data, X.indices, X.indptr, n_bins, codes, mean_vec)
+        else:
+            from pegasus.cylib.fast_utils import calc_sig_background_sparse_no_std
+            return calc_sig_background_sparse_no_std(X.shape[0], X.shape[1], X.data, X.indices, X.indptr, n_bins, codes, mean_vec), None
     else:
-        from pegasus.cylib.fast_utils import calc_sig_background_dense
-        return calc_sig_background_dense(X.shape[0], X.shape[1], X, n_bins, codes, mean_vec)
+        if standardize:
+            from pegasus.cylib.fast_utils import calc_sig_background_dense
+            return calc_sig_background_dense(X.shape[0], X.shape[1], X, n_bins, codes, mean_vec)
+        else:
+            from pegasus.cylib.fast_utils import calc_sig_background_dense_no_std
+            return calc_sig_background_dense_no_std(X.shape[0], X.shape[1], X, n_bins, codes, mean_vec), None
 
 
 def simulate_doublets(X: Union[csr_matrix, np.ndarray], sim_doublet_ratio: float, random_state: int = 0) -> Tuple[Union[csr_matrix, np.ndarray], np.ndarray]:


### PR DESCRIPTION
## Issue

When estimating background signature given a sparse count matrix, in `pegasus.cylib.calc_sig_background_sparse` function, the calculation ignores zero entries of the matrix, while their centered expression should be considered because the gene mean expressions are likely non-zero.

However, if given a dense count matrix, the calculation does not have this issue since it uses a different Cython function `pegasus.cylib.calc_sig_background_dense`.

## Solution

Include all entries during the calculation, with tricks to speed up.

## Other improvement

Add `standardize` parameter to `calc_signature_score` function to allow return non-standardized signature scores. By default, standardize the scores.