### PR TITLE
Fix doublet detection

### DIFF
--- a/pegasus/tools/doublet_detection.py
+++ b/pegasus/tools/doublet_detection.py
@@ -197,7 +197,7 @@ def _find_local_maxima(y: List[float], frac: float = 0.25, merge_peak_frac: floa
 
         RETURNS:
           maxima: merged peak coordinates sorted y in descending order
-          maxima_by_x: passing filter but not merged peak coordiantes sorted by x
+          peak_groups: map of merged peak coordinates to their corresponding unmerged peak coordinates, which all pass the filter
           filtered_maxima: filtered peak coordinates
     """
     lower_bound = y.max() * frac
@@ -214,7 +214,6 @@ def _find_local_maxima(y: List[float], frac: float = 0.25, merge_peak_frac: floa
     filtered_maxima = np.array(filtered_maxima, dtype=int)
     n_max = maxima_by_x.size
 
-    print(f"maxima_by_x = {maxima_by_x}")
     peak_groups = dict()
 
     curr_peak = 0
@@ -350,10 +349,6 @@ def _find_score_threshold(sim_scores, d_neo, threshold_guide, threshold_expected
 
     # Find local maxima
     maxima, peak_groups, filtered_maxima = _find_local_maxima(y)
-    print(f"maxima = {maxima}")
-    print(f"peak_groups = {peak_groups}")
-    print(f"filtered_maxima = {filtered_maxima}")
-    print(f"threshold_expected = {threshold_expected}")
     assert maxima.size > 0
 
     # Calculate curvature


### PR DESCRIPTION
* Use merged peaks to decide cutoff
  * `_find_local_maxima()` returns a map of merged peaks to unmerged peaks (all pass filter), which will be used later in `_find_cutoff_right_side()`.
  * Remove `maxima_by_x` from `_find_local_maxima()` return objects, as it's not used afterwards.
* Fix the logic in `_find_curv_local_minima()`:
  * For the case when `pos_to <= pos_from`, instead of assertion failure, return `pos_to` as there is no local minima within the range. So the next step is to find a positive curvature position leftward ignoring this range.
  * Finally, if the local minima does not pass the threshold, instead of assertion failure, return `pos_to - 1`, so that the next step will find a positive curvature position leftward still including this range.